### PR TITLE
Fixed issue with extra spaces being added to LLM responses during combine.

### DIFF
--- a/current/requirements.txt
+++ b/current/requirements.txt
@@ -4,3 +4,6 @@ langchain
 huggingface-hub
 sentence-transformers
 python-dotenv
+langchain_community
+langchain_huggingface
+chromadb

--- a/current/td-llm-dnd.py
+++ b/current/td-llm-dnd.py
@@ -71,7 +71,8 @@ def api_call(model: str, prompt: str, max_tokens: int) -> str:
             return "Error: No valid JSON objects found in response."
 
 
-        combined_response = " ".join([obj.get("response", "") for obj in json_objects])
+        combined_response = "".join([obj.get("response", "") for obj in json_objects])
+        
         return combined_response
 
     except requests.RequestException as e:
@@ -141,6 +142,7 @@ def manage_models():
     player_model = st.selectbox("AI Player Model", models,
                                 index=models.index(st.session_state.get('player_model', models[0])))
     embedding_model = st.selectbox("RAG Embedding Model", ["sentence-transformers/all-mpnet-base-v2",
+                                                           "sentence-transformers/all-MiniLM-L12-v2",
                                                            "sentence-transformers/all-MiniLM-L6-v2"])
 
     if st.button("Save Model Selections"):


### PR DESCRIPTION
**About**
I noticed that when generating players the markdown was not rendering properly and there were random word splits. I have corrected this by changing how llm responses are combined.

**Changes**

- combining response with  `"".join` instead of `" ".join` 
- added extra sentence-transformer for fun
- adding missing dependencies to the requirements.txt file